### PR TITLE
fix: CIのDenoバージョンを1.46.2に更新

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
         uses: denoland/setup-deno@v1
         with:
           # Slack CLI では。最新の stable version の Deno を利用することを推奨します
-          deno-version: v1.43.6
+          deno-version: v1.46.2
 
       - name: Cache Slack CLI installation
         id: cache-slack

--- a/deno.lock
+++ b/deno.lock
@@ -1,5 +1,5 @@
 {
-  "version": "2",
+  "version": "4",
   "remote": {
     "https://deno.land/std@0.134.0/_deno_unstable.ts": "23a1a36928f1b6d3b0170aaa67de09af12aa998525f608ff7331b9fb364cbde6",
     "https://deno.land/std@0.134.0/_util/assert.ts": "e94f2eb37cebd7f199952e242c77654e43333c1ac4c5c700e929ea3aa5489f74",
@@ -393,9 +393,12 @@
     "https://deno.land/x/deno_slack_hooks@1.0.1/build.ts": "f080d8c26b9a7723c1270be22253d04169363b8301101deacc1a1a37a6eb1a4e",
     "https://deno.land/x/deno_slack_hooks@1.0.1/check_update.ts": "3726ea1aaf78eb8b55bfb4f5dcafbf72a2f0b3d6cbbc800d29e40131cca05148",
     "https://deno.land/x/deno_slack_hooks@1.0.1/deps.ts": "01db4bca5d66b71196e0298c207e8c58bc2122312efe7e97b185a59a45af2504",
+    "https://deno.land/x/deno_slack_hooks@1.0.1/flags.ts": "ddcfe7f58323e9fc125369621b326d80da422df59cd50b458cd91aa43bf93fe3",
     "https://deno.land/x/deno_slack_hooks@1.0.1/get_manifest.ts": "4e2350e3629fc4e716689c09d9f4fda3d9bc9f7b0b952bd9afa6157e41c6b854",
     "https://deno.land/x/deno_slack_hooks@1.0.1/get_trigger.ts": "d80813dd55af498fa49da5d10656b1751147d37e89a839835b9e20da2cc5ca38",
+    "https://deno.land/x/deno_slack_hooks@1.0.1/install_update.ts": "01fef9bb5a13e4d31cd947ca5188d8f17f6752565609d6e5de9c40b4773b7234",
     "https://deno.land/x/deno_slack_hooks@1.0.1/libraries.ts": "48c3cc3471615a1f57e67a695505e56a403818db01cfb6958d513c181614fad7",
+    "https://deno.land/x/deno_slack_hooks@1.0.1/mod.ts": "232a91532c834665407d1542b81bc7461b6a8b0dcac5a65a9bc74596c395a5c0",
     "https://deno.land/x/deno_slack_hooks@1.0.1/utilities.ts": "809a36c2a82986045f778d1cd74d026cb906498891545e55b92df82704b0492b",
     "https://deno.land/x/deno_slack_hooks@1.0.1/version.ts": "6c0bc17b89d018157f67954907919c64a0e1b0d079d33b785c71ccbf287ab9d1",
     "https://deno.land/x/deno_slack_protocols@0.0.2/deps.ts": "8ff2d185ecc28403588fdc108c58bb5d77181a67f209af29932ec1029cbf94e6",

--- a/slack.json
+++ b/slack.json
@@ -1,5 +1,5 @@
 {
   "hooks": {
-    "get-hooks": "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@1.0.1/mod.ts"
+    "get-hooks": "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@1.3.2/mod.ts"
   }
 }


### PR DESCRIPTION
## 概要 CI環境でSlack CLI のDeno バージョン要件エラーが発生していたため、Denoを1.43.6から1.46.2にアップデートしました。 ## 変更内容 - GitHub Actions の deploy.yml でDeno バージョンを v1.43.6 → v1.46.2 に更新 - Slack CLI が要求する最低バージョン 1.46.2 を満たすように修正 ## 解決される問題  このエラーが解決されます。