### PR TITLE
fix: Slackマニフェストソース設定を追加

### DIFF
--- a/.slack/config.json
+++ b/.slack/config.json
@@ -1,3 +1,6 @@
 {
-  "project_id": "2e867aa5-8132-402c-af71-f2dbe9c8e230"
+  "project_id": "2e867aa5-8132-402c-af71-f2dbe9c8e230",
+  "manifest": {
+    "source": "local"
+  }
 }


### PR DESCRIPTION
## 概要 CI環境でSlackマニフェストエラーが発生していたため、.slack/config.jsonにマニフェストソース設定を追加しました。 ## 変更内容 - .slack/config.json に manifest.source を local として追加 ## 解決される問題  および  これらのエラーが解決されます。